### PR TITLE
Install jack on win32 builds

### DIFF
--- a/linux.mingw/Dockerfile
+++ b/linux.mingw/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y    \
         lsb-release                         \
         nsis                                \
         cloog-isl                           \
-        jack                                \
+        libjack-dev                         \
         libmpc3                             \
         mingw-w64                           \
         mingw-w64-tools                     \

--- a/linux.mingw/Dockerfile
+++ b/linux.mingw/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y    \
         lsb-release                         \
         nsis                                \
         cloog-isl                           \
+        jack                                \
         libmpc3                             \
         mingw-w64                           \
         mingw-w64-tools                     \


### PR DESCRIPTION
We only will be using it for its headers.