### PR TITLE
MinGW: Add the `file` command

### DIFF
--- a/linux.mingw/Dockerfile
+++ b/linux.mingw/Dockerfile
@@ -35,4 +35,5 @@ RUN apt-get update && apt-get install -y    \
         qt5base-mingw-w64                   \
         sdl-mingw-w64                       \
         stk-mingw-w64                       \
+        file                                \
 && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
In order to support automatic bundling using cmake's BundleUtils, we need `file`.