### PR TITLE
Use Ubuntu 20.04 for MinGW images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,37 +24,45 @@ shared: &shared
         paths:
           - ./image.tar.gz
 
+focal: &focal
+  <<: *shared
+  environment:
+    UBUNTU_VERSION: "20.04"
+
 version: 2
 jobs:
   base:18.04:
     <<: *shared
+  base:20.04:
+    <<: *focal
   linux:18.04:
     <<: *shared
   linux.gcc:18.04:
     <<: *shared
-  linux.mingw:18.04:
-    <<: *shared
-  linux.mingw32:18.04:
-    <<: *shared
-  linux.mingw64:18.04:
-    <<: *shared
+  linux.mingw:20.04:
+    <<: *focal
+  linux.mingw32:20.04:
+    <<: *focal
+  linux.mingw64:20.04:
+    <<: *focal
 workflows:
   version: 2
   build_images:
     jobs:
       - base:18.04
+      - base:20.04
       - linux:18.04:
           requires:
            - base:18.04
       - linux.gcc:18.04:
           requires:
            - linux:18.04
-      - linux.mingw:18.04:
+      - linux.mingw:20.04:
           requires:
-           - base:18.04
-      - linux.mingw32:18.04:
+           - base:20.04
+      - linux.mingw32:20.04:
           requires:
-           - linux.mingw:18.04
-      - linux.mingw64:18.04:
+           - linux.mingw:20.04
+      - linux.mingw64:20.04:
           requires:
-           - linux.mingw:18.04
+           - linux.mingw:20.04

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:${UBUNTU_VERSION}
 ARG UBUNTU_VERSION
 
 ENV UBUNTU_VERSION ${UBUNTU_VERSION}
+ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && apt-get install -y    \
     --no-install-recommends                 \

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -14,26 +14,13 @@ RUN apt-get update && apt-get install -y    \
     cmake                                   \
     git                                     \
     ssh-client                              \
+    ccache                                  \
     perl                                    \
     libxml2-utils                           \
     libxml-perl                             \
     liblist-moreutils-perl                  \
 && rm -rf /var/lib/apt/lists/*
 
-RUN if [ "$UBUNTU_VERSION" = "18.04" ]; then           \
-    apt-get update && apt-get install -y               \
-        qt5-default qttools5-dev-tools                 \
-;else                                                  \
-    add-apt-repository ppa:beineri/opt-qt563-xenial && \
-    apt-get update && apt-get install -y               \
-        qt56base qt56tools                             \
-;fi                                                    \
+RUN apt-get update && apt-get install -y    \
+        qt5-default qttools5-dev-tools      \
 && rm -rf /var/lib/apt/lists/*
-
-ADD ccache.sha256 /tmp/ccache/ccache.sha256
-ADD http://archive.ubuntu.com/ubuntu/pool/main/c/ccache/ccache_3.4.1-1_amd64.deb /tmp/ccache/
-
-RUN cd /tmp/ccache && \
-    sha256sum -c ccache.sha256 && \
-    dpkg -i ccache_3.4.1-1_amd64.deb && \
-    rm -r /tmp/ccache

--- a/base/ccache.sha256
+++ b/base/ccache.sha256
@@ -1,1 +1,0 @@
-58af42f4128a36206ccfeda487e8fc5e7be881c8e0ca84a43e97d572293c4f53  ccache_3.4.1-1_amd64.deb

--- a/linux.mingw/Dockerfile
+++ b/linux.mingw/Dockerfile
@@ -13,7 +13,6 @@ RUN apt-get update && apt-get install -y    \
     --force-yes --no-install-recommends     \
         lsb-release                         \
         nsis                                \
-        cloog-isl                           \
         libmpc3                             \
         mingw-w64                           \
         mingw-w64-tools                     \
@@ -33,7 +32,7 @@ RUN apt-get update && apt-get install -y    \
         libz-mingw-w64-dev                  \
         portaudio-mingw-w64                 \
         qt5base-mingw-w64                   \
-        sdl-mingw-w64                       \
+        sdl2-mingw-w64                      \
         stk-mingw-w64                       \
         file                                \
 && rm -rf /var/lib/apt/lists/*

--- a/linux.mingw/Dockerfile
+++ b/linux.mingw/Dockerfile
@@ -1,4 +1,4 @@
-FROM lmmsci/base:18.04
+FROM lmmsci/base:20.04
 
 RUN apt-get update && apt-get install -y \
     --no-install-recommends              \
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y \
         gnupg                            \
 && rm -rf /var/lib/apt/lists/*
 
-RUN echo "deb http://ppa.launchpad.net/tobydox/mingw-w64/ubuntu bionic main" >> /etc/apt/sources.list
+RUN echo "deb http://ppa.launchpad.net/tobydox/mingw-w64/ubuntu focal main" >> /etc/apt/sources.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 72931B477E22FEFD47F8DECE02FE5F12ADDE29B2
 
 RUN apt-get update && apt-get install -y    \

--- a/linux.mingw32/Dockerfile
+++ b/linux.mingw32/Dockerfile
@@ -1,1 +1,1 @@
-FROM lmmsci/linux.mingw:18.04
+FROM lmmsci/linux.mingw:20.04

--- a/linux.mingw64/Dockerfile
+++ b/linux.mingw64/Dockerfile
@@ -1,1 +1,1 @@
-FROM lmmsci/linux.mingw:18.04
+FROM lmmsci/linux.mingw:20.04


### PR DESCRIPTION
To use the [updated packages from Toby's PPA](https://launchpad.net/~tobydox/+archive/ubuntu/mingw-w64?field.series_filter=focal) for MinGW builds.
This also addresses https://github.com/LMMS/lmms/pull/5160#issuecomment-548268679 since the version of `qt5base-mingw-w64` and `qt5svg-mingw-w64` should match now.