### PR TITLE
Add FFmpeg to Docker images

### DIFF
--- a/linux.mingw/Dockerfile
+++ b/linux.mingw/Dockerfile
@@ -37,6 +37,10 @@ RUN apt-get update && apt-get install -y    \
         file                                \
 && rm -rf /var/lib/apt/lists/*
 
+# Compile FFmpeg for MinGW
+# Can be removed once MinGW packages are added in @tobydox's PPA.
+RUN ./compile-ffmpeg.sh
+
 # Work around https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=930492
 # FIXME remove once we upgrade to 22.04
 ADD mingw-w64-tools.sha256 /tmp/mingw-w64-tools/mingw-w64-tools.sha256

--- a/linux.mingw/compile-ffmpeg.sh
+++ b/linux.mingw/compile-ffmpeg.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env sh
+
+configure_install_ffmpeg() 
+{
+  CROSS_PREFIX=$1
+  ./configure \
+    --arch=x86 \
+    --target-os=mingw32 \
+    --enable-cross-compile \
+    --prefix=/usr/$CROSS_PREFIX \
+    --cross-prefix=$CROSS_PREFIX- \
+    --host-cc=$CROSS_PREFIX-gcc \
+    --x86asmexe=yasm \
+    --enable-shared \
+    --disable-static \
+    --disable-debug \
+    --disable-programs \
+    --disable-doc
+  make && make install
+}
+
+# YASM is recommended when compiling FFmpeg 
+apt-get install yasm -y
+
+git clone -c http.sslVerify=false https://git.ffmpeg.org/ffmpeg.git /tmp/ffmpeg
+cd /tmp/ffmpeg
+
+configure_install_ffmpeg i686-w64-mingw32
+configure_install_ffmpeg x86_64-w64-mingw32

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -37,4 +37,13 @@ RUN apt-get update -qq &&       \
         libxcb-keysyms1-dev     \
         libxcb-util0-dev        \
         qtbase5-private-dev     \
+        libavcodec-dev          \
+        libavdevice-dev         \
+        libavfilter-dev         \
+        libavformat-dev         \
+        libavresample-dev       \
+        libavutil-dev           \
+        libpostproc-dev         \
+        libswresample-dev       \
+        libswscale-dev          \
 && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Add FFmpeg to the CI Docker images. Compiling FFmpeg for MinGW can be removed once the necessary packages are provided by @tobydox's PPA.