### PR TITLE
Update Linux images

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -22,5 +22,6 @@ RUN apt-get update && apt-get install -y    \
 && rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update && apt-get install -y    \
-        qt5-default qttools5-dev-tools      \
+    qt5-default                             \
+    qttools5-dev-tools                      \
 && rm -rf /var/lib/apt/lists/*

--- a/build-image-manual.sh
+++ b/build-image-manual.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# Usage: ./build-image.sh <image> <version>
+# Example usage: ./build-image.sh linux.gcc 20.04
+
+# IMPORTANT: For Linux builds, set UBUNTU_VERSION prior to calling:
+#export UBUNTU_VERSION=20.04
+
+IMAGE_USER=ghcr.io/lmms
+IMAGE_PREFIX=
+
+DOCKERFILE=$1
+TAG=$2
+
+IMAGE=$IMAGE_USER/$IMAGE_PREFIX$DOCKERFILE
+
+log() {
+    echo -e "\e[35m[build-image.sh]\e[39m $@"
+}
+
+log "Pulling old image version"
+if docker pull $IMAGE:$TAG; then
+    CACHE_FROM="--cache-from $IMAGE:$TAG"
+elif docker pull $IMAGE:latest; then
+    CACHE_FROM="--cache-from $IMAGE:latest"
+else
+    log "No image found, building without cache"
+fi
+
+log "Building image from Dockerfile"
+docker build            \
+    --tag $IMAGE:$TAG   \
+    $CACHE_FROM         \
+    --build-arg UBUNTU_VERSION="$UBUNTU_VERSION" \
+    $DOCKERFILE
+
+# Finally, push to ghcr.io after building (must be logged in first):
+#docker push ghcr.io/lmms/linux.gcc:20.04

--- a/linux.gcc/Dockerfile
+++ b/linux.gcc/Dockerfile
@@ -1,14 +1,14 @@
 ARG UBUNTU_VERSION
-FROM lmmsci/linux:${UBUNTU_VERSION}
+FROM ghcr.io/lmms/linux:${UBUNTU_VERSION}
 
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && apt-get install -y    \
-    # Needed for AppImage:                  \
+# Needed for AppImage:
     stk                                     \
     wget                                    \
-    file									\
-    # for vst
+    file                                    \
+# Needed for VST:
     libwine-dev                             \
     libwine-dev:i386                        \
     wine64-tools                            \

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -1,5 +1,5 @@
 ARG UBUNTU_VERSION
-FROM lmmsci/base:${UBUNTU_VERSION}
+FROM ghcr.io/lmms/base:${UBUNTU_VERSION}
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -21,7 +21,7 @@ RUN apt-get update -qq &&       \
         liblilv-dev             \
         libogg-dev              \
         libsamplerate0-dev      \
-        libsdl-dev              \
+        libsdl2-dev             \
         libsndfile1-dev         \
         libstk0-dev             \
         libvorbis-dev           \
@@ -31,10 +31,13 @@ RUN apt-get update -qq &&       \
         portaudio19-dev         \
         gcc-multilib            \
         g++-multilib            \
-        qt5-default             \
+        qt5-qmake               \
         qtbase5-dev             \
+        qtbase5-dev-tools       \
+        qtbase5-private-dev     \
+        qttools5-dev-tools      \
         libqt5x11extras5-dev    \
+        libx11-xcb-dev          \
         libxcb-keysyms1-dev     \
         libxcb-util0-dev        \
-        qtbase5-private-dev     \
 && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Companion PR to https://github.com/LMMS/lmms/pull/7015

- Updated Linux images to work with Ubuntu 20.04 (focal)
- Changed package hosting from [Docker Hub](https://hub.docker.com/u/lmmsci) to [ghcr.io](https://github.com/orgs/lmms/packages) (GitHub Packages) for Linux

NOTE: I initially considered migrating this repo from CircleCI to GitHub Actions, but I do not think it will be worth it if our longer term goal is to use plain GitHub runners instead of these Docker images. However, I did add a script for manually building the Docker images just to make it clear how it is done, which will be helpful in case we ever need to do this again.