### PR TITLE
CMake update

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -5,23 +5,41 @@ ARG UBUNTU_VERSION
 ENV UBUNTU_VERSION ${UBUNTU_VERSION}
 ENV DEBIAN_FRONTEND noninteractive
 
+# Kitware APT repo for latest CMake --- See: https://apt.kitware.com/
 RUN apt-get update && apt-get install -y    \
     --no-install-recommends                 \
-    ca-certificates                         \
-    software-properties-common              \
-    make                                    \
-    libc6-dev                               \
-    cmake                                   \
-    git                                     \
-    ssh-client                              \
-    ccache                                  \
-    perl                                    \
-    libxml2-utils                           \
-    libxml-perl                             \
-    liblist-moreutils-perl                  \
-&& rm -rf /var/lib/apt/lists/*
+        ca-certificates                     \
+        gpg                                 \
+        lsb-release                         \
+        wget                                \
+    && rm -rf /var/lib/apt/lists/*
+RUN test -f /usr/share/doc/kitware-archive-keyring/copyright || \
+    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null \
+    | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+RUN echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $(lsb_release -c -s) main" \
+    | tee /etc/apt/sources.list.d/kitware.list >/dev/null \
+    && apt-get update
+RUN test -f /usr/share/doc/kitware-archive-keyring/copyright || \
+    rm /usr/share/keyrings/kitware-archive-keyring.gpg
+RUN apt-get install kitware-archive-keyring
+
+# Install common dependencies
+RUN apt-get update && apt-get install -y    \
+    --no-install-recommends                 \
+        software-properties-common          \
+        make                                \
+        libc6-dev                           \
+        cmake                               \
+        git                                 \
+        ssh-client                          \
+        ccache                              \
+        perl                                \
+        libxml2-utils                       \
+        libxml-perl                         \
+        liblist-moreutils-perl              \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update && apt-get install -y    \
-    qt5-default                             \
-    qttools5-dev-tools                      \
-&& rm -rf /var/lib/apt/lists/*
+        qt5-default                         \
+        qttools5-dev-tools                  \
+    && rm -rf /var/lib/apt/lists/*

--- a/build-image-manual.sh
+++ b/build-image-manual.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
 
-# Usage: ./build-image.sh <image> <version>
-# Example usage: ./build-image.sh linux.gcc 20.04
+# Usage: ./build-image-manual.sh <image> <version>
+# Example usage:
+#     ./build-image-manual.sh base 20.04
+#     ./build-image-manual.sh linux 20.04
+#     ./build-image-manual.sh linux.gcc 20.04
 
 # IMPORTANT: For Linux builds, set UBUNTU_VERSION prior to calling:
 #export UBUNTU_VERSION=20.04
@@ -15,7 +18,7 @@ TAG=$2
 IMAGE=$IMAGE_USER/$IMAGE_PREFIX$DOCKERFILE
 
 log() {
-    echo -e "\e[35m[build-image.sh]\e[39m $@"
+    echo "\e[35m[build-image-manual.sh]\e[39m $@"
 }
 
 log "Pulling old image version"
@@ -35,4 +38,6 @@ docker build            \
     $DOCKERFILE
 
 # Finally, push to ghcr.io after building (must be logged in first):
+#docker push ghcr.io/lmms/base:20.04
+#docker push ghcr.io/lmms/linux:20.04
 #docker push ghcr.io/lmms/linux.gcc:20.04

--- a/linux.mingw/Dockerfile
+++ b/linux.mingw/Dockerfile
@@ -1,4 +1,4 @@
-FROM lmmsci/base:20.04
+FROM ghcr.io/lmms/base:20.04
 
 RUN apt-get update && apt-get install -y \
     --no-install-recommends              \
@@ -11,7 +11,6 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 72931B477E22FEFD47F
 
 RUN apt-get update && apt-get install -y    \
     --force-yes --no-install-recommends     \
-        lsb-release                         \
         nsis                                \
         libmpc3                             \
         mingw-w64                           \

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -17,13 +17,14 @@ RUN apt-get update -qq &&       \
         libfluidsynth-dev       \
         libgig-dev              \
         libjack-jackd2-dev      \
-        libmp3lame-dev          \
         liblilv-dev             \
+        libmp3lame-dev          \
         libogg-dev              \
         libsamplerate0-dev      \
         libsdl2-dev             \
         libsndfile1-dev         \
         libstk0-dev             \
+        libsuil-dev             \
         libvorbis-dev           \
         libxft-dev              \
         libxinerama-dev         \
@@ -40,4 +41,4 @@ RUN apt-get update -qq &&       \
         libx11-xcb-dev          \
         libxcb-keysyms1-dev     \
         libxcb-util0-dev        \
-&& rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
- Migrate the MinGW image to ghcr.io
- Use Kitware's APT repo to install the latest stable CMake for all images (currently 3.29.3)
- Add `libsuil-dev` to the Linux image for LV2 UI support
- Update the manual build script

Once this is approved, I can push the new Linux images to ghcr.io so the builds can pick them up.