### PR TITLE
Dependency update

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -26,17 +26,18 @@ RUN apt-get install kitware-archive-keyring
 # Install common dependencies
 RUN apt-get update && apt-get install -y    \
     --no-install-recommends                 \
-        software-properties-common          \
-        make                                \
-        libc6-dev                           \
+        binutils                            \
+        ccache                              \
         cmake                               \
         git                                 \
-        ssh-client                          \
-        ccache                              \
-        perl                                \
+        libc6-dev                           \
+        liblist-moreutils-perl              \
         libxml2-utils                       \
         libxml-perl                         \
-        liblist-moreutils-perl              \
+        make                                \
+        perl                                \
+        software-properties-common          \
+        ssh-client                          \
     && rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update && apt-get install -y    \

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update && apt-get install -y    \
     && rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update && apt-get install -y    \
-        qt5-default                         \
+        qt5-qmake                           \
+        qtbase5-dev                         \
         qttools5-dev-tools                  \
     && rm -rf /var/lib/apt/lists/*

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -5,30 +5,15 @@ ARG UBUNTU_VERSION
 ENV UBUNTU_VERSION ${UBUNTU_VERSION}
 ENV DEBIAN_FRONTEND noninteractive
 
-# Kitware APT repo for latest CMake --- See: https://apt.kitware.com/
-RUN apt-get update && apt-get install -y    \
-    --no-install-recommends                 \
-        ca-certificates                     \
-        gpg                                 \
-        lsb-release                         \
-        wget                                \
-    && rm -rf /var/lib/apt/lists/*
-RUN test -f /usr/share/doc/kitware-archive-keyring/copyright || \
-    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null \
-    | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
-RUN echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $(lsb_release -c -s) main" \
-    | tee /etc/apt/sources.list.d/kitware.list >/dev/null \
-    && apt-get update
-RUN test -f /usr/share/doc/kitware-archive-keyring/copyright || \
-    rm /usr/share/keyrings/kitware-archive-keyring.gpg
-RUN apt-get install kitware-archive-keyring
+# Install CMake
+ADD install-cmake.sh scripts/
+RUN scripts/install-cmake.sh
 
 # Install common dependencies
 RUN apt-get update && apt-get install -y    \
     --no-install-recommends                 \
         binutils                            \
         ccache                              \
-        cmake                               \
         git                                 \
         libc6-dev                           \
         liblist-moreutils-perl              \

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -5,25 +5,29 @@ ARG UBUNTU_VERSION
 ENV UBUNTU_VERSION ${UBUNTU_VERSION}
 ENV DEBIAN_FRONTEND noninteractive
 
-# Install CMake
-ADD install-cmake.sh scripts/
-RUN scripts/install-cmake.sh
-
 # Install common dependencies
 RUN apt-get update && apt-get install -y    \
     --no-install-recommends                 \
         binutils                            \
+        ca-certificates                     \
         ccache                              \
         git                                 \
+        gpg                                 \
         libc6-dev                           \
         liblist-moreutils-perl              \
         libxml2-utils                       \
         libxml-perl                         \
+        lsb-release                         \
         make                                \
         perl                                \
         software-properties-common          \
         ssh-client                          \
+        wget                                \
     && rm -rf /var/lib/apt/lists/*
+
+# Install CMake
+ADD install-cmake.sh scripts/
+RUN scripts/install-cmake.sh
 
 RUN apt-get update && apt-get install -y    \
         qt5-qmake                           \

--- a/base/install-cmake.sh
+++ b/base/install-cmake.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# Kitware APT repo for latest CMake --- See: https://apt.kitware.com/
+# As of 5/21/2024, only focal and jammy are supported
+if [ "$UBUNTU_VERSION" = "20.04" ] || [ "$UBUNTU_VERSION" = "22.04" ]; then
+    apt-get update && apt-get install -y    \
+        --no-install-recommends             \
+            ca-certificates                 \
+            gpg                             \
+            lsb-release                     \
+            wget                            \
+        && rm -rf /var/lib/apt/lists/*
+    test -f /usr/share/doc/kitware-archive-keyring/copyright || \
+    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null \
+        | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+    echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $(lsb_release -c -s) main" \
+        | tee /etc/apt/sources.list.d/kitware.list >/dev/null \
+        && apt-get update
+    test -f /usr/share/doc/kitware-archive-keyring/copyright || \
+        rm /usr/share/keyrings/kitware-archive-keyring.gpg
+    apt-get install kitware-archive-keyring
+fi
+
+apt-get update && apt-get install -y    \
+        cmake                           \
+    && rm -rf /var/lib/apt/lists/*

--- a/base/install-cmake.sh
+++ b/base/install-cmake.sh
@@ -3,13 +3,6 @@
 # Kitware APT repo for latest CMake --- See: https://apt.kitware.com/
 # As of 5/21/2024, only focal and jammy are supported
 if [ "$UBUNTU_VERSION" = "20.04" ] || [ "$UBUNTU_VERSION" = "22.04" ]; then
-    apt-get update && apt-get install -y    \
-        --no-install-recommends             \
-            ca-certificates                 \
-            gpg                             \
-            lsb-release                     \
-            wget                            \
-        && rm -rf /var/lib/apt/lists/*
     test -f /usr/share/doc/kitware-archive-keyring/copyright || \
     wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null \
         | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null

--- a/build-image-manual.sh
+++ b/build-image-manual.sh
@@ -6,9 +6,6 @@
 #     ./build-image-manual.sh linux 20.04
 #     ./build-image-manual.sh linux.gcc 20.04
 
-# IMPORTANT: For Linux builds, set UBUNTU_VERSION prior to calling:
-#export UBUNTU_VERSION=20.04
-
 IMAGE_USER=ghcr.io/lmms
 IMAGE_PREFIX=
 
@@ -34,7 +31,7 @@ log "Building image from Dockerfile"
 docker build            \
     --tag $IMAGE:$TAG   \
     $CACHE_FROM         \
-    --build-arg UBUNTU_VERSION="$UBUNTU_VERSION" \
+    --build-arg UBUNTU_VERSION="$TAG" \
     $DOCKERFILE
 
 # Finally, push to ghcr.io after building (must be logged in first):

--- a/linux.gcc/Dockerfile
+++ b/linux.gcc/Dockerfile
@@ -21,4 +21,5 @@ RUN mkdir -pm755 /etc/apt/keyrings \
 RUN apt-get update && apt-get install -y    \
     --install-recommends                    \
         winehq-staging                      \
+        wine-staging-dev                    \
     && rm -rf /var/lib/apt/lists/*

--- a/linux.gcc/Dockerfile
+++ b/linux.gcc/Dockerfile
@@ -3,14 +3,22 @@ FROM ghcr.io/lmms/linux:${UBUNTU_VERSION}
 
 ENV DEBIAN_FRONTEND noninteractive
 
+# AppImage dependencies
 RUN apt-get update && apt-get install -y    \
     --no-install-recommends                 \
-# Needed for AppImage:
+        file                                \
         stk                                 \
         wget                                \
-        file                                \
-# Needed for VST:
-        libwine-dev                         \
-        libwine-dev:i386                    \
-        wine64-tools                        \
+    && rm -rf /var/lib/apt/lists/*
+
+# Add WineHQ repo
+RUN mkdir -pm755 /etc/apt/keyrings \
+    && wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key \
+    && UBUNTU_CODENAME=$(lsb_release -c -s) \
+    && wget -NP /etc/apt/sources.list.d/ "https://dl.winehq.org/wine-builds/ubuntu/dists/${UBUNTU_CODENAME}/winehq-${UBUNTU_CODENAME}.sources"
+
+# VST dependencies
+RUN apt-get update && apt-get install -y    \
+    --install-recommends                    \
+        winehq-staging                      \
     && rm -rf /var/lib/apt/lists/*

--- a/linux.gcc/Dockerfile
+++ b/linux.gcc/Dockerfile
@@ -4,12 +4,13 @@ FROM ghcr.io/lmms/linux:${UBUNTU_VERSION}
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && apt-get install -y    \
+    --no-install-recommends                 \
 # Needed for AppImage:
-    stk                                     \
-    wget                                    \
-    file                                    \
+        stk                                 \
+        wget                                \
+        file                                \
 # Needed for VST:
-    libwine-dev                             \
-    libwine-dev:i386                        \
-    wine64-tools                            \
-&& rm -rf /var/lib/apt/lists/*
+        libwine-dev                         \
+        libwine-dev:i386                    \
+        wine64-tools                        \
+    && rm -rf /var/lib/apt/lists/*

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -32,8 +32,6 @@ RUN apt-get update -qq &&       \
         portaudio19-dev         \
         gcc-multilib            \
         g++-multilib            \
-        qt5-qmake               \
-        qtbase5-dev             \
         qtbase5-dev-tools       \
         qtbase5-private-dev     \
         qttools5-dev-tools      \

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update -qq &&       \
         libsamplerate0-dev      \
         libsdl2-dev             \
         libsndfile1-dev         \
-        libstk0-dev             \
+        libstk-dev              \
         libsuil-dev             \
         libvorbis-dev           \
         libxft-dev              \


### PR DESCRIPTION
Changes:
- Added `binutils` to Linux and MinGW
- Replaced the default APT Wine headers with `winehq-staging` and `wine-staging-dev` to provide the latest Wine (currently version 9.9) regardless of Ubuntu version
- Enabled Ubuntu 24.04 support for Linux builds
  - Replaced a Qt package that was removed after focal
  - Replaced `libstk0-dev` with `libstk-dev`
  - In Ubuntu 24.04 only, used the default `cmake` instead of the Kitware APT `cmake` (Kitware hasn't updated their APT repo to support noble yet)
  - I've already pushed these images to ghcr.io
- Removed some unnecessary "recommended" packages to save space
- Simplified `build-image-manual.sh` usage

If everything looks good, I will push the new images to ghcr.io